### PR TITLE
[FEATURE] Improve attachments

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -28,9 +28,11 @@ use Mittwald\Typo3Forum\Domain\Model\Forum\Attachment;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Post;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
 use Mittwald\Typo3Forum\Domain\Model\User\FrontendUser;
+use Mittwald\Typo3Forum\Utility\Configuration;
 use Mittwald\Typo3Forum\Utility\Localization;
 
 use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 
 class PostController extends AbstractController
@@ -70,6 +72,21 @@ class PostController extends AbstractController
      * @inject
      */
     protected $topicRepository;
+
+    /**
+     * @var \Mittwald\Typo3Forum\Utility\configuration
+     */
+    private $configuration;
+
+    /**
+     * Initialize object
+     *
+     * @access public
+     */
+    public function initializeObject()
+    {
+        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
+    }
 
     /**
      * Listing Action
@@ -240,7 +257,10 @@ class PostController extends AbstractController
             $this->authenticationService->assertEditPostAuthorization($post);
         }
 
+        $maxFileUploadSize = $this->configuration->getMaxFileUploadSize();
         $this->view->assignMultiple([
+            'maxFileUploadSizeNumeric' => $this->configuration->convertToBytes($maxFileUploadSize),
+            'maxFileUploadSize' => $maxFileUploadSize,
             'topic' => $topic,
             'post' => $post,
             'posts' => $posts,
@@ -313,7 +333,13 @@ class PostController extends AbstractController
             // Assert authorization
             $this->authenticationService->assertModerationAuthorization($post->getTopic()->getForum());
         }
-        $this->view->assign('post', $post);
+
+        $maxFileUploadSize = $this->configuration->getMaxFileUploadSize();
+        $this->view->assignMultiple([
+            'maxFileUploadSizeNumeric' => $this->configuration->convertToBytes($maxFileUploadSize),
+            'maxFileUploadSize' => $maxFileUploadSize,
+            'post' => $post
+        ]);
     }
 
     /**

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -226,6 +226,8 @@ class PostController extends AbstractController
         // Assert authorization
         $this->authenticationService->assertNewPostAuthorization($topic);
 
+        $posts = $this->postRepository->findForTopic($topic);
+
         // If no post is specified, create an optionally pre-filled post (if a
         // quoted post was specified).
         if ($post === null) {
@@ -241,6 +243,7 @@ class PostController extends AbstractController
         $this->view->assignMultiple([
             'topic' => $topic,
             'post' => $post,
+            'posts' => $posts,
             'currentUser' => $this->frontendUserRepository->findCurrent()
         ]);
     }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -352,9 +352,6 @@ class PostController extends AbstractController
      */
     public function updateAction(Post $post, array $attachments = [])
     {
-        // @TODO use proper Extbase code to retrieve POST data
-        $selectedFiles = $_POST['tx_typo3forum_pi1']['deleteAttachment'];
-
         if ($post->getAuthor() != $this->authenticationService->getUser()
           || $post->getTopic()->getLastPost()->getAuthor() != $post->getAuthor()
         ) {
@@ -364,13 +361,22 @@ class PostController extends AbstractController
 
         $getAllAttachments  = $post->getAttachments();
 
+        // Determine attachments to be deleted (if any)
+        $attachmentsToDelete = [];
+        if ($this->request->hasArgument('deleteAttachment')) {
+            $arguments = $this->request->getArguments();
+            if (is_array($arguments['deleteAttachment'])) {
+                $attachmentsToDelete = $arguments['deleteAttachment'];
+            }
+        }
+
         // Delete selected attachments
-        if (count($selectedFiles) > 0) {
+        if (count($attachmentsToDelete) > 0) {
             $getAllAttachments->rewind();
             while ($getAllAttachments->valid()) {
                 $storedObject = $getAllAttachments->current();
                 $getExistingFile = $storedObject->getFilename();
-                if (in_array($getExistingFile, $selectedFiles)) {
+                if (in_array($getExistingFile, $attachmentsToDelete)) {
                     if (file_exists($storedObject->getAbsoluteFilename())) {
                         unlink($storedObject->getAbsoluteFilename());
                     }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -375,8 +375,8 @@ class PostController extends AbstractController
             $allAttachments->rewind();
             while ($allAttachments->valid()) {
                 $storedObject = $allAttachments->current();
-                $getExistingFile = $storedObject->getFilename();
-                if (in_array($getExistingFile, $attachmentsToDelete)) {
+                $currentFileName = $storedObject->getFilename();
+                if (in_array($currentFileName, $attachmentsToDelete)) {
                     if (file_exists($storedObject->getAbsoluteFilename())) {
                         unlink($storedObject->getAbsoluteFilename());
                     }

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Mittwald\Typo3Forum\Controller;
 
 /*                                                                      *
@@ -73,7 +72,9 @@ class PostController extends AbstractController
     protected $topicRepository;
 
     /**
-     *  Listing Action.
+     * Listing Action
+     *
+     * @access public
      * @return void
      */
     public function listAction()
@@ -99,6 +100,9 @@ class PostController extends AbstractController
     }
 
     /**
+     * Add supporter action
+     *
+     * @access public
      * @param Post $post
      * @return string
      */
@@ -140,6 +144,9 @@ class PostController extends AbstractController
     }
 
     /**
+     * Remove supporter action
+     *
+     * @access public
      * @param Post $post
      * @return string
      */
@@ -178,6 +185,7 @@ class PostController extends AbstractController
      * topic that contains the requested post.
      * This function is called by post summaries (last post link)
      *
+     * @access public
      * @param Post $post The post
      * @param Post $quote The Quote
      * @param int $showForm ShowForm
@@ -207,6 +215,7 @@ class PostController extends AbstractController
      *
      * @dontvalidate $post
      *
+     * @access public
      * @param Topic $topic The topic in which the new post is to be created.
      * @param Post $post The new post.
      * @param Post $quote An optional post that will be quoted within the bodytext of the new post.
@@ -239,12 +248,13 @@ class PostController extends AbstractController
     /**
      * Creates a new post.
      *
+     * @validate $post \Mittwald\Typo3Forum\Domain\Validator\Forum\PostValidator
+     * @validate $attachments \Mittwald\Typo3Forum\Domain\Validator\Forum\AttachmentPlainValidator
+     *
+     * @access public
      * @param Topic $topic The topic in which the new post is to be created.
      * @param Post $post The new post.
      * @param array $attachments File attachments for the post.
-     *
-     * @validate $post \Mittwald\Typo3Forum\Domain\Validator\Forum\PostValidator
-     * @validate $attachments \Mittwald\Typo3Forum\Domain\Validator\Forum\AttachmentPlainValidator
      */
     public function createAction(Topic $topic, Post $post, array $attachments = [])
     {
@@ -287,6 +297,8 @@ class PostController extends AbstractController
      * Displays a form for editing a post.
      *
      * @dontvalidate $post
+     *
+     * @access public
      * @param Post $post The post that is to be edited.
      * @return void
      */
@@ -304,9 +316,9 @@ class PostController extends AbstractController
     /**
      * Updates a post.
      *
+     * @access public
      * @param Post $post The post that is to be updated.
      * @param array $attachments File attachments for the post.
-     *
      * @return void
      */
     public function updateAction(Post $post, array $attachments = [])
@@ -365,6 +377,7 @@ class PostController extends AbstractController
      * Displays a confirmation screen in which the user is prompted if a post
      * should really be deleted.
      *
+     * @access public
      * @param Post $post The post that is to be deleted.
      * @return void
      */
@@ -377,6 +390,7 @@ class PostController extends AbstractController
     /**
      * Deletes a post.
      *
+     * @access public
      * @param Post $post The post that is to be deleted.
      * @return void
      */
@@ -412,6 +426,8 @@ class PostController extends AbstractController
 
     /**
      * Displays a preview of a rendered post text.
+     *
+     * @access public
      * @param string $text The content.
      */
     public function previewAction($text)
@@ -421,6 +437,8 @@ class PostController extends AbstractController
 
     /**
      * Downloads an attachment and increase the download counter
+     *
+     * @access public
      * @param \Mittwald\Typo3Forum\Domain\Model\Forum\Attachment $attachment
      */
     public function downloadAttachmentAction($attachment)

--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -359,7 +359,7 @@ class PostController extends AbstractController
             $this->authenticationService->assertModerationAuthorization($post->getTopic()->getForum());
         }
 
-        $getAllAttachments  = $post->getAttachments();
+        $allAttachments  = $post->getAttachments();
 
         // Determine attachments to be deleted (if any)
         $attachmentsToDelete = [];
@@ -372,17 +372,17 @@ class PostController extends AbstractController
 
         // Delete selected attachments
         if (count($attachmentsToDelete) > 0) {
-            $getAllAttachments->rewind();
-            while ($getAllAttachments->valid()) {
-                $storedObject = $getAllAttachments->current();
+            $allAttachments->rewind();
+            while ($allAttachments->valid()) {
+                $storedObject = $allAttachments->current();
                 $getExistingFile = $storedObject->getFilename();
                 if (in_array($getExistingFile, $attachmentsToDelete)) {
                     if (file_exists($storedObject->getAbsoluteFilename())) {
                         unlink($storedObject->getAbsoluteFilename());
                     }
-                    $getAllAttachments->detach($storedObject);
+                    $allAttachments->detach($storedObject);
                 } else {
-                    $getAllAttachments->next();
+                    $allAttachments->next();
                 }
             }
         }

--- a/Classes/Controller/TopicController.php
+++ b/Classes/Controller/TopicController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Mittwald\Typo3Forum\Controller;
 
 /*                                                                      *
@@ -32,7 +31,6 @@ use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
 
 class TopicController extends AbstractController
 {
-
     /**
      * @var \Mittwald\Typo3Forum\Domain\Repository\Forum\AdRepository
      * @inject
@@ -105,7 +103,9 @@ class TopicController extends AbstractController
     protected $topicRepository;
 
     /**
+     * Initialize object
      *
+     * @access public
      */
     public function initializeObject()
     {
@@ -113,7 +113,9 @@ class TopicController extends AbstractController
     }
 
     /**
-     *  Listing Action.
+     * Listing Action.
+     *
+     * @access public
      * @return void
      */
     public function listAction()
@@ -126,16 +128,21 @@ class TopicController extends AbstractController
                 $partial = 'Topic/List';
                 break;
             case '3':
-                $dataset = $this->topicRepository->findQuestions(intval($this->settings['maxTopicItems']));
+                $dataset = $this->topicRepository->findQuestions(
+                    intval($this->settings['maxTopicItems'])
+                );
                 $partial = 'Topic/QuestionBox';
                 break;
             case '4':
-                $dataset = $this->topicRepository->findPopularTopics(intval($this->settings['popularTopicTimeDiff']), intval($this->settings['maxTopicItems']));
+                $dataset = $this->topicRepository->findPopularTopics(
+                    intval($this->settings['popularTopicTimeDiff']),
+                    intval($this->settings['maxTopicItems'])
+                );
                 $partial = 'Topic/ListBox';
                 break;
             default:
-                $dataset      = $this->topicRepository->findAll();
-                $partial      = 'Topic/List';
+                $dataset = $this->topicRepository->findAll();
+                $partial = 'Topic/List';
                 $showPaginate = true;
                 break;
         }
@@ -145,7 +152,9 @@ class TopicController extends AbstractController
     }
 
     /**
-     *  Listing Action.
+     * List latest action.
+     *
+     * @access public
      */
     public function listLatestAction()
     {
@@ -162,6 +171,7 @@ class TopicController extends AbstractController
     /**
      * Show action. Displays a single topic and all posts contained in this topic.
      *
+     * @access public
      * @param Topic $topic The topic that is to be displayed.
      * @param Post $quote An optional post that will be quoted within the bodytext of the new post.
      * @param int $showForm ShowForm
@@ -223,6 +233,11 @@ class TopicController extends AbstractController
     /**
      * Creates a new topic.
      *
+     * @validate $post \Mittwald\Typo3Forum\Domain\Validator\Forum\PostValidator
+     * @validate $attachments \Mittwald\Typo3Forum\Domain\Validator\Forum\AttachmentPlainValidator
+     * @validate $subject NotEmpty
+     *
+     * @access public
      * @param Forum $forum The forum in which the new topic is to be created.
      * @param Post $post The first post of the new topic.
      * @param string $subject The subject of the new topic
@@ -231,14 +246,17 @@ class TopicController extends AbstractController
      * @param array $criteria All submitted criteria with option.
      * @param string $tags All defined tags for this topic
      * @param string $subscribe The flag if the new topic is subscribed by author
-     *
-     * @validate $post \Mittwald\Typo3Forum\Domain\Validator\Forum\PostValidator
-     * @validate $attachments \Mittwald\Typo3Forum\Domain\Validator\Forum\AttachmentPlainValidator
-     * @validate $subject NotEmpty
      */
-    public function createAction(Forum $forum, Post $post, $subject, $attachments = [], $question = '', $criteria = [], $tags = '', $subscribe = '')
-    {
-
+    public function createAction(
+        Forum $forum,
+        Post $post,
+        $subject,
+        $attachments = [],
+        $question = '',
+        $criteria = [],
+        $tags = '',
+        $subscribe = ''
+    ) {
         // Assert authorization
         $this->authenticationService->assertNewTopicAuthorization($forum);
 
@@ -263,7 +281,15 @@ class TopicController extends AbstractController
             $tags = null;
         }
 
-        $topic = $this->topicFactory->createTopic($forum, $post, $subject, (int)$question, $criteria, $tags, (int)$subscribe);
+        $topic = $this->topicFactory->createTopic(
+            $forum,
+            $post,
+            $subject,
+            intval($question),
+            $criteria,
+            $tags,
+            intval($subscribe)
+        );
 
         // Notify potential listeners.
         $this->signalSlotDispatcher->dispatch(
@@ -293,8 +319,8 @@ class TopicController extends AbstractController
     /**
      * Sets a post as solution
      *
+     * @access public
      * @param Post $post The post to be marked as solution.
-     *
      * @throws NoAccessException
      */
     public function solutionAction(Post $post)
@@ -315,8 +341,8 @@ class TopicController extends AbstractController
     /**
      * Marks a topic as read by the current user.
      *
+     * @access public
      * @param Topic $topic The topic that is to be marked as read.
-     *
      */
     protected function markTopicRead(Topic $topic)
     {

--- a/Classes/Controller/TopicController.php
+++ b/Classes/Controller/TopicController.php
@@ -28,6 +28,9 @@ use Mittwald\Typo3Forum\Domain\Exception\Authentication\NoAccessException;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Forum;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Post;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
+use Mittwald\Typo3Forum\Utility\Configuration;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class TopicController extends AbstractController
 {
@@ -103,12 +106,18 @@ class TopicController extends AbstractController
     protected $topicRepository;
 
     /**
+     * @var \Mittwald\Typo3Forum\Utility\configuration
+     */
+    private $configuration;
+
+    /**
      * Initialize object
      *
      * @access public
      */
     public function initializeObject()
     {
+        $this->configuration = GeneralUtility::makeInstance(Configuration::class);
         $this->databaseConnection = $GLOBALS['TYPO3_DB'];
     }
 
@@ -220,8 +229,11 @@ class TopicController extends AbstractController
      */
     public function newAction(Forum $forum, Post $post = null, $subject = null)
     {
+        $maxFileUploadSize = $this->configuration->getMaxFileUploadSize();
         $this->authenticationService->assertNewTopicAuthorization($forum);
         $this->view->assignMultiple([
+            'maxFileUploadSizeNumeric' => $this->configuration->convertToBytes($maxFileUploadSize),
+            'maxFileUploadSize' => $maxFileUploadSize,
             'criteria' => $forum->getCriteria(),
             'currentUser' => $this->frontendUserRepository->findCurrent(),
             'forum' => $forum,

--- a/Classes/Domain/Factory/Forum/PostFactory.php
+++ b/Classes/Domain/Factory/Forum/PostFactory.php
@@ -57,7 +57,6 @@ class PostFactory extends AbstractFactory
      */
     public function createEmptyPost()
     {
-        \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump($this, __METHOD__);
         return $this->getClassInstance();
     }
 

--- a/Classes/Domain/Model/Forum/Post.php
+++ b/Classes/Domain/Model/Forum/Post.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Mittwald\Typo3Forum\Domain\Model\Forum;
 
 /* *
@@ -39,7 +38,6 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  */
 class Post extends AbstractEntity implements AccessibleInterface, NotifiableInterface
 {
-
     /**
      * The post text.
      *
@@ -98,6 +96,11 @@ class Post extends AbstractEntity implements AccessibleInterface, NotifiableInte
     protected $attachments;
 
     /**
+     * @var string
+     */
+    protected $deleteAttachment;
+
+    /**
      * helpfull count
      * @var int
      */
@@ -133,6 +136,7 @@ class Post extends AbstractEntity implements AccessibleInterface, NotifiableInte
             '_languageUid' => $this->_languageUid,
             '_versionedUid' => $this->_versionedUid,
             'pid' => $this->getPid(),
+            'deleteAttachment' => $this->getDeleteAttachment(),
         ];
     }
 
@@ -478,5 +482,15 @@ class Post extends AbstractEntity implements AccessibleInterface, NotifiableInte
     public function removeAllSupporters()
     {
         $this->supporters = new ObjectStorage();
+    }
+
+    /**
+     * Gets all attachments which should be deleted
+     *
+     * @return array;
+     */
+    public function getDeleteAttachment()
+    {
+        return $this->deleteAttachment;
     }
 }

--- a/Classes/Service/AttachmentService.php
+++ b/Classes/Service/AttachmentService.php
@@ -1,15 +1,18 @@
 <?php
-
 namespace Mittwald\Typo3Forum\Service;
 
+use Mittwald\Typo3Forum\Domain\Model\Forum\Attachment;
+
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
 class AttachmentService implements SingletonInterface
 {
-
     /**
-     * An instance of the Extbase object manager.
+     * Instance of the Extbase object manager.
+     *
+     * @access protected
      * @var \TYPO3\CMS\Extbase\Object\ObjectManagerInterface
      * @inject
      */
@@ -17,6 +20,8 @@ class AttachmentService implements SingletonInterface
 
     /**
      * Converts HTML-array to an object
+     *
+     * @access public
      * @param array $attachments
      * @return ObjectStorage
      */
@@ -25,30 +30,37 @@ class AttachmentService implements SingletonInterface
         /* @var \Mittwald\Typo3Forum\Domain\Model\Forum\Attachment */
         $objAttachments = new ObjectStorage();
 
-        foreach ($attachments as $attachmentID => $attachment) {
-            if ($attachment['name'] == '') {
-                continue;
-            }
-            $tmp_name = $_FILES['tx_typo3forum_pi1']['tmp_name']['attachments'][$attachmentID];
-            $mime_type = mime_content_type($tmp_name);
+        foreach ($attachments as $attachment) {
+            foreach ($attachment as $attachmentID => $eachAttachment) {
+                if ($eachAttachment['name'] == '') {
+                    continue;
+                }
+                $tmp_name = $_FILES['tx_typo3forum_pi1']['tmp_name']['attachments'][$attachmentID];
 
-            //Save in ObjectStorage and in file system
-            $attachmentObj = $this->objectManager->get(\Mittwald\Typo3Forum\Domain\Model\Forum\Attachment::class);
-            $attachmentObj->setFilename($attachment['name']);
-            $attachmentObj->setRealFilename(sha1($attachment['name'] . time()));
-            $attachmentObj->setMimeType($mime_type);
+                // Save in ObjectStorage and file system
+                $attachmentObj = $this->objectManager->get(Attachment::class);
+                $attachmentObj->setFilename($eachAttachment['name']);
+                $attachmentObj->setRealFilename(sha1($eachAttachment['name'] . time()));
 
-            //Create dir if not exists
-            $tca = $attachmentObj->getTCAConfig();
-            $path = $tca['columns']['real_filename']['config']['uploadfolder'];
-            if (!file_exists($path)) {
-                mkdir($path, 0777, true);
-            }
+                //$attachmentObj->setMimeType(mime_content_type($tmp_name));
+                $attachmentObj->setMimeType($eachAttachment['type']);
 
-            //upload file and put in object storage
-            $res = \TYPO3\CMS\Core\Utility\GeneralUtility::upload_copy_move($tmp_name, $attachmentObj->getAbsoluteFilename());
-            if ($res === true) {
-                $objAttachments->attach($attachmentObj);
+                // Create directory if it does not exist
+                $tca = $attachmentObj->getTCAConfig();
+                $path = $tca['columns']['real_filename']['config']['uploadfolder'];
+                if (!file_exists($path)) {
+                    // @TODO fix insecure permissions
+                    mkdir($path, 0777, true);
+                }
+
+                // Move uploaded file to final location
+                $res = GeneralUtility::upload_copy_move(
+                    $eachAttachment['tmp_name'],
+                    $attachmentObj->getAbsoluteFilename()
+                );
+                if ($res === true) {
+                    $objAttachments->attach($attachmentObj);
+                }
             }
         }
         return $objAttachments;

--- a/Classes/Utility/Configuration.php
+++ b/Classes/Utility/Configuration.php
@@ -1,0 +1,53 @@
+<?php
+namespace Mittwald\Typo3Forum\Utility;
+
+/**
+ * Utility module for various configurations
+ */
+class Configuration
+{
+    /**
+     * Returns the max file upload size as configured in PHP (php.ini).
+     * Setting "upload_max_filesize" and "post_max_size" are taken into account.
+     * The lower value is returned.
+     *
+     * @access public
+     * @return string Human-readable representation of value
+     */
+    public function getMaxFileUploadSize()
+    {
+        $checkSettings = ['upload_max_filesize', 'post_max_size'];
+        $lowerValue = ini_get($checkSettings[0]);
+        foreach ($checkSettings as $setting) {
+            $value = ini_get($setting);
+            if ($this->convertToBytes($value) < $this->convertToBytes($lowerValue)) {
+                $lowerValue = $value;
+            }
+        }
+        return $lowerValue;
+    }
+
+    /**
+     * Converts a human-readable value, e.g. 10M, to a numeric bytes representation
+     *
+     * @access public
+     * @param string Human-readable representation of value
+     * @return int Numeric representation of value
+     */
+    public function convertToBytes($humanReadableValue)
+    {
+        switch (substr($humanReadableValue, -1)) {
+            case 'M':
+            case 'm':
+                return intval($humanReadableValue) * 1048576;
+            case 'K':
+            case 'k':
+                return intval($humanReadableValue) * 1024;
+            case 'G':
+            case 'g':
+                return int($humanReadableValue) * 1073741824;
+            default:
+                return $humanReadableValue;
+        }
+    }
+}

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -78,6 +78,7 @@
 			<label index="Post_New_Additional_Attachment">Additional attachment</label>
 			<label index="Post_Show_Attachment_DownloadCount">Downloaded %d times</label>
 			<label index="Post_Show_Attachments">Attachments</label>
+			<label index="Post_Delete_Attachment">Delete</label>
 			<label index="Post_Show_QuoteBy">Quote by</label>
 			<label index="Post_Show_Solution_New">Is solution</label>
 			<label index="Post_Show_Solution_Edit">Replace solution</label>
@@ -383,6 +384,7 @@ Your ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Doplňující příloha</label>
 			<label index="Post_Show_Attachment_DownloadCount">Staženo %dx</label>
 			<label index="Post_Show_Attachments">Přílohy</label>
+			<label index="Post_Delete_Attachment">избрисати</label>
 			<label index="Post_Show_QuoteBy">Citoval</label>
 			<label index="Post_Show_Solution_New">Stávající řešení</label>
 			<label index="Post_Show_Solution_Edit">Nahradit řešení</label>
@@ -684,6 +686,7 @@ Your ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Weiterer Anhang</label>
 			<label index="Post_Show_Attachment_DownloadCount">%d heruntergeladen</label>
 			<label index="Post_Show_Attachments">Anhänge</label>
+			<label index="Post_Delete_Attachment">Löschen</label>
 			<label index="Post_Show_QuoteBy">Zitiert von:</label>
 			<label index="Post_Show_Solution_New">Ist Lösung</label>
 			<label index="Post_Show_Solution_Edit">Lösung ersetzen</label>
@@ -982,6 +985,7 @@ Dein ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Archivo adjunto adicional</label>
 			<label index="Post_Show_Attachment_DownloadCount">Descargado %d veces</label>
 			<label index="Post_Show_Attachments">Adjuntos</label>
+			<label index="Post_Delete_Attachment">Borrar</label>
 			<label index="Post_Show_QuoteBy">Cita de:</label>
 			<label index="Post_Show_Solution_New">Como solución</label>
 			<label index="Post_Show_Solution_Edit">Sustituir solución</label>
@@ -1278,6 +1282,7 @@ Dein ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Pièce-jointe supplémentaire</label>
 			<label index="Post_Show_Attachment_DownloadCount">Téléchargé %d fois</label>
 			<label index="Post_Show_Attachments">Pièces-jointes</label>
+			<label index="Post_Delete_Attachment">Effacer</label>
 			<label index="Post_Show_QuoteBy">Cité par</label>
 			<label index="Post_Show_Solution_New">Est la solution</label>
 			<label index="Post_Show_Solution_Edit">Remplacer la solution</label>
@@ -1576,6 +1581,7 @@ Dein ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Altro allegato</label>
 			<label index="Post_Show_Attachment_DownloadCount">%d scaricato</label>
 			<label index="Post_Show_Attachments">Allegati</label>
+			<label index="Post_Delete_Attachments">Elimina</label>
 			<label index="Post_Show_QuoteBy">Quotato da:</label>
 			<label index="Post_Show_Solution_New">È la soluzione</label>
 			<label index="Post_Show_Solution_Edit">Sostituisci soluzione</label>
@@ -1883,6 +1889,7 @@ Dein ###FORUM_NAME###-Team</label>
 			<label index="Post_New_Additional_Attachment">Дополнительное приложение</label>
 			<label index="Post_Show_Attachment_DownloadCount">Загружено %d раз</label>
 			<label index="Post_Show_Attachments">Вложения</label>
+			<label index="Post_Show_Attachments">удалять</label>
 			<label index="Post_Show_QuoteBy">Цитируется из:</label>
 			<label index="Post_Show_Solution_New">Решение</label>
 			<label index="Post_Show_Solution_Edit">Заменить решение</label>

--- a/Resources/Private/Partials/Bootstrap/Post/Form.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Form.html
@@ -4,9 +4,9 @@
 $(document).ready(function() {
 });
 function validate() {
-	var file_size = $('#att')[0].files[0].size / 1000;
-	if (file_size > 2000) {
-		alert("Uploaded file(s) size should be less than 2MB");
+	var file_size = $('#att')[0].files[0].size;
+	if (file_size > {maxFileUploadSizeNumeric}) {
+		alert("Uploaded file(s) size should be less than {maxFileUploadSize} bytes");
 		return false;
 	}
 	return true;

--- a/Resources/Private/Partials/Bootstrap/Post/Form.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Form.html
@@ -1,15 +1,16 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
 <script type="text/javascript">
-	$(document).ready(function() {
-	function validate() {
-		var file_size = $('#att')[0].files[0].size / 1000;
-		if (file_size > 2000) {
-			alert("Uploaded file(s) size should be less than 2MB");
-			return false;
-		}
-		return true;
+$(document).ready(function() {
+});
+function validate() {
+	var file_size = $('#att')[0].files[0].size / 1000;
+	if (file_size > 2000) {
+		alert("Uploaded file(s) size should be less than 2MB");
+		return false;
 	}
+	return true;
+}
 </script>
 <f:form name="post" object="{post}" controller="Post" action="{action}" id="post" class="form-horizontal" enctype="multipart/form-data">
 	<fieldset>
@@ -50,7 +51,7 @@
 
 		<b:form.row>
 			<f:form.upload name="attachments[0]" multiple="1" id="att" />
-			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;"><i class="fa fa-times" aria-hidden="true" style="fontsize:18px;color:#000;"></i></a>
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;">X</a>
 			<style>#att{float:left;}</style>
 			<script>
 				function clearUpload(){

--- a/Resources/Private/Partials/Bootstrap/Post/Form.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Form.html
@@ -1,5 +1,16 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
+<script type="text/javascript">
+	$(document).ready(function() {
+	function validate() {
+		var file_size = $('#att')[0].files[0].size / 1000;
+		if (file_size > 2000) {
+			alert("Uploaded file(s) size should be less than 2MB");
+			return false;
+		}
+		return true;
+	}
+</script>
 <f:form name="post" object="{post}" controller="Post" action="{action}" id="post" class="form-horizontal" enctype="multipart/form-data">
 	<fieldset>
 		<legend>
@@ -29,17 +40,36 @@
 			<f:if condition="{post.attachments}">
 				<f:for each="{post.attachments}" as="attachment">
 					<div>
-						{attachment.filename},
+						<f:form.checkbox name="deleteAttachment[]" value="{attachment.filename}" />
+						<f:translate key="Post_Delete_Attachment" /> - {attachment.filename},
 						<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
 					</div>
 				</f:for>
 			</f:if>
-			<f:form.upload name="attachments[0]"/>
 		</b:form.row>
+
+		<b:form.row>
+			<f:form.upload name="attachments[0]" multiple="1" id="att" />
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;"><i class="fa fa-times" aria-hidden="true" style="fontsize:18px;color:#000;"></i></a>
+			<style>#att{float:left;}</style>
+			<script>
+				function clearUpload(){
+					$("#att").replaceWith($("#att").val('').clone(true));
+				}
+			</script>
+		</b:form.row>
+
 		<div class="form-actions">
-			<f:form.hidden name="topic" value="{topic}"/>
-			<f:form.submit value="{f:translate(key: 'Post_New_Submit')}" class="btn btn-primary"/>
-			<b:button controller="Topic" action="show" arguments="{topic:topic}" label="Button_Back"/>
+			<f:form.hidden name="topic" value="{topic}" />
+			<f:if condition="{post.uid}">
+				<f:then>
+					<f:form.submit value="{f:translate(key: 'Post_Edit')}" class="btn btn-primary" onclick="return validate();" />
+				</f:then>
+				<f:else>
+					<f:form.submit value="{f:translate(key: 'Post_New_Submit')}" class="btn btn-primary" onclick="return validate();" />
+				</f:else>
+			</f:if>
+			<b:button controller="Topic" action="show" arguments="{topic:topic}" label="Button_Back" />
 		</div>
 	</fieldset>
 </f:form>

--- a/Resources/Private/Partials/Standard/Post/Form.html
+++ b/Resources/Private/Partials/Standard/Post/Form.html
@@ -4,9 +4,9 @@
 $(document).ready(function() {
 });
 function validate() {
-	var file_size = $('#att')[0].files[0].size / 1000;
-	if (file_size > 2000) {
-		alert("Uploaded file(s) size should be less than 2MB");
+	var file_size = $('#att')[0].files[0].size;
+	if (file_size > {maxFileUploadSizeNumeric}) {
+		alert("Uploaded file(s) size should be less than {maxFileUploadSize} bytes");
 		return false;
 	}
 	return true;

--- a/Resources/Private/Partials/Standard/Post/Form.html
+++ b/Resources/Private/Partials/Standard/Post/Form.html
@@ -1,5 +1,17 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
+<script type="text/javascript">
+$(document).ready(function() {
+});
+function validate() {
+	var file_size = $('#att')[0].files[0].size / 1000;
+	if (file_size > 2000) {
+		alert("Uploaded file(s) size should be less than 2MB");
+		return false;
+	}
+	return true;
+}
+</script>
 <f:form name="post" object="{post}" controller="Post" action="{action}" id="post" enctype="multipart/form-data">
     <fieldset>
         <legend>
@@ -27,19 +39,38 @@
                                    class="tx-typo3forum-editor span8"/>
         </b:form.row>
         <b:form.row llLabel="Post_New_Attachments">
-            <f:if condition="{post.attachments}">
-                <f:for each="{post.attachments}" as="attachment">
-                    <div>
-                        {attachment.filename},
-                        <mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
-                    </div>
-                </f:for>
-            </f:if>
-            <f:form.upload name="attachments[0]"/>
-        </b:form.row>
+			<f:if condition="{post.attachments}">
+				<f:for each="{post.attachments}" as="attachment">
+					<div>
+						<f:form.checkbox name="deleteAttachment[]" value="{attachment.filename}" />
+						<f:translate key="Post_Delete_Attachment" /> - {attachment.filename},
+						<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
+					</div>
+				</f:for>
+			</f:if>
+		</b:form.row>
+
+        <b:form.row>
+			<f:form.upload name="attachments[0]" multiple="1" id="att" />
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;">X</a>
+			<style>#att{float:left;}</style>
+			<script>
+				function clearUpload(){
+					$("#att").replaceWith($("#att").val('').clone(true));
+				}
+			</script>
+		</b:form.row>
+
         <div>
             <f:form.hidden name="topic" value="{topic}"/>
-            <f:form.submit value="{f:translate(key: 'Post_New_Submit')}"/>
+			<f:if condition="{post.uid}">
+				<f:then>
+					<f:form.submit value="{f:translate(key: 'Post_Edit')}" class="btn btn-primary" onclick="return validate();" />
+				</f:then>
+				<f:else>
+					<f:form.submit value="{f:translate(key: 'Post_New_Submit')}" class="btn btn-primary" onclick="return validate();" />
+				</f:else>
+			</f:if>
             <b:button controller="Topic" action="show" arguments="{topic:topic}" label="Button_Back"/>
         </div>
     </fieldset>

--- a/Resources/Private/Templates/Bootstrap/Post/Edit.html
+++ b/Resources/Private/Templates/Bootstrap/Post/Edit.html
@@ -3,7 +3,7 @@
 
 <f:section name="main">
 	<f:render partial="FormErrors"/>
-	<f:render partial="Post/Form" arguments="{post: post, topic: post.topic, action: 'update'}"/>
+	<f:render partial="Post/Form" arguments="{post: post, topic: post.topic, action: 'update', maxFileUploadSizeNumeric: maxFileUploadSizeNumeric, maxFileUploadSize: maxFileUploadSize}"/>
 </f:section>
 
 

--- a/Resources/Private/Templates/Bootstrap/Post/New.html
+++ b/Resources/Private/Templates/Bootstrap/Post/New.html
@@ -9,7 +9,7 @@
 	<h2>
 		<f:translate key="Post_New" arguments="{0: topic.subject}" />
 	</h2>
-	<f:render partial="Post/Form" arguments="{post: post, topic: topic, action: 'create', currentUser: currentUser}" />
+	<f:render partial="Post/Form" arguments="{post: post, topic: topic, action: 'create', currentUser: currentUser, maxFileUploadSizeNumeric: maxFileUploadSizeNumeric, maxFileUploadSize: maxFileUploadSize}" />
 </f:section>
 
 

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -1,13 +1,10 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
-
 <f:layout name="default"/>
-
-
 <f:section name="main">
-<script type="text/javascript">
+	<script type="text/javascript">
 	$(document).ready(function() {
-
+	});
 	function validate() {
 		var file_size = $('#att')[0].files[0].size / 1000;
 		if (file_size > 2000) {
@@ -16,7 +13,8 @@
 		}
 		return true;
 	}
-</script>
+	</script>
+
 	<f:render partial="FormErrors"/>
 
 	<h2>
@@ -52,7 +50,7 @@
 
 			<b:form.row>
 			<f:form.upload name="attachments[0]" multiple="1" id="att" />
-			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;"><i class="fa fa-times" aria-hidden="true" style="fontsize:18px;color:#000;"></i></a>
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;">X</a>
 			<style>#att{float:left;}</style>
 			<script>
 				function clearUpload(){

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -5,7 +5,18 @@
 
 
 <f:section name="main">
+<script type="text/javascript">
+	$(document).ready(function() {
 
+	function validate() {
+		var file_size = $('#att')[0].files[0].size / 1000;
+		if (file_size > 2000) {
+			alert("Uploaded file(s) size should be less than 2MB");
+			return false;
+		}
+		return true;
+	}
+</script>
 	<f:render partial="FormErrors"/>
 
 	<h2>
@@ -31,12 +42,23 @@
 				<f:if condition="{post.attachments}">
 					<f:for each="{post.attachments}" as="attachment">
 						<div>
-							{attachment.filename},
+								<f:form.checkbox name="deleteAttachment[]" value="{attachment.filename}" />
+								<f:translate key="Post_Delete_Attachment" /> - {attachment.filename},
 							<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
 						</div>
 					</f:for>
 				</f:if>
-				<f:form.upload name="attachments[0]"/>
+				</b:form.row>
+
+			<b:form.row>
+			<f:form.upload name="attachments[0]" multiple="1" id="att" />
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;"><i class="fa fa-times" aria-hidden="true" style="fontsize:18px;color:#000;"></i></a>
+			<style>#att{float:left;}</style>
+			<script>
+				function clearUpload(){
+					$("#att").replaceWith($("#att").val('').clone(true));
+				}
+			</script>
 			</b:form.row>
 			<b:form.row llLabel="Topic_New_Subscribe">
 				<label class="checkbox">

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -6,9 +6,9 @@
 	$(document).ready(function() {
 	});
 	function validate() {
-		var file_size = $('#att')[0].files[0].size / 1000;
-		if (file_size > 2000) {
-			alert("Uploaded file(s) size should be less than 2MB");
+		var file_size = $('#att')[0].files[0].size;
+		if (file_size > {maxFileUploadSizeNumeric}) {
+			alert("Uploaded file(s) size should be less than {maxFileUploadSize} bytes");
 			return false;
 		}
 		return true;

--- a/Resources/Private/Templates/Standard/Topic/New.html
+++ b/Resources/Private/Templates/Standard/Topic/New.html
@@ -6,6 +6,18 @@
 
 <f:section name="main">
     <!-- template: Standard/Topic/New.html -->
+	<script type="text/javascript">
+	$(document).ready(function() {
+	});
+	function validate() {
+		var file_size = $('#att')[0].files[0].size / 1000;
+		if (file_size > 2000) {
+			alert("Uploaded file(s) size should be less than 2MB");
+			return false;
+		}
+		return true;
+	}
+	</script>
 
 	<f:render partial="FormErrors"/>
 
@@ -32,13 +44,25 @@
 				<f:if condition="{post.attachments}">
 					<f:for each="{post.attachments}" as="attachment">
 						<div>
-							{attachment.filename},
+							<f:form.checkbox name="deleteAttachment[]" value="{attachment.filename}" />
+							<f:translate key="Post_Delete_Attachment" /> - {attachment.filename},
 							<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
 						</div>
 					</f:for>
 				</f:if>
-				<f:form.upload name="attachments[0]"/>
 			</b:form.row>
+
+			<b:form.row>
+			<f:form.upload name="attachments[0]" multiple="1" id="att" />
+			<a href="javascript:void(0);" onclick="clearUpload();" style="display:block;float:left;font-size: 24px;">X</a>
+			<style>#att{float:left;}</style>
+			<script>
+				function clearUpload(){
+					$("#att").replaceWith($("#att").val('').clone(true));
+				}
+			</script>
+			</b:form.row>
+
 			<b:form.row llLabel="Topic_New_Subscribe">
 				<label >
 					<f:form.checkbox name="subscribe" value="1"/>

--- a/Resources/Private/Templates/Standard/Topic/New.html
+++ b/Resources/Private/Templates/Standard/Topic/New.html
@@ -10,9 +10,9 @@
 	$(document).ready(function() {
 	});
 	function validate() {
-		var file_size = $('#att')[0].files[0].size / 1000;
-		if (file_size > 2000) {
-			alert("Uploaded file(s) size should be less than 2MB");
+		var file_size = $('#att')[0].files[0].size;
+		if (file_size > {maxFileUploadSizeNumeric}) {
+			alert("Uploaded file(s) size should be less than {maxFileUploadSize} bytes");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
This change extends the TYPO3 Forum extension by the following features.

* allow users to add **multiple** attachments by selecting more than one file in browser
* allow users to **delete** attachments (edit post → delete)

In addition, files involved in this change have been cleaned up to follow PSR-2 coding guidelines and some missing comments/annotations have been added.
