### PR TITLE
[BUGFIX] Remove empty jQuery DOM readiness detection

### DIFF
--- a/Resources/Private/Partials/Bootstrap/Post/Form.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Form.html
@@ -1,8 +1,6 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
 <script type="text/javascript">
-$(document).ready(function() {
-});
 function validate() {
 	var file_size = $('#att')[0].files[0].size;
 	if (file_size > {maxFileUploadSizeNumeric}) {

--- a/Resources/Private/Partials/Standard/Post/Form.html
+++ b/Resources/Private/Partials/Standard/Post/Form.html
@@ -1,8 +1,6 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
 {namespace b=Mittwald\Typo3Forum\ViewHelpers\Bootstrap}
 <script type="text/javascript">
-$(document).ready(function() {
-});
 function validate() {
 	var file_size = $('#att')[0].files[0].size;
 	if (file_size > {maxFileUploadSizeNumeric}) {

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -3,8 +3,6 @@
 <f:layout name="default"/>
 <f:section name="main">
 	<script type="text/javascript">
-	$(document).ready(function() {
-	});
 	function validate() {
 		var file_size = $('#att')[0].files[0].size;
 		if (file_size > {maxFileUploadSizeNumeric}) {

--- a/Resources/Private/Templates/Standard/Topic/New.html
+++ b/Resources/Private/Templates/Standard/Topic/New.html
@@ -7,8 +7,6 @@
 <f:section name="main">
     <!-- template: Standard/Topic/New.html -->
 	<script type="text/javascript">
-	$(document).ready(function() {
-	});
 	function validate() {
 		var file_size = $('#att')[0].files[0].size;
 		if (file_size > {maxFileUploadSizeNumeric}) {


### PR DESCRIPTION
jQuery detects if a document is in "ready" state and the page can be manipulated safely. However, an empty jQuery DOM readiness detection is not only pointless, but can cause JavaScript errors/warnings and has an impact on performance.

This update removes these empty jQuery DOM readiness detection.
```
$(document).ready(function() {
});
```