### PR TITLE
[FEATURE] Decouple editor and single post display from templates

### DIFF
--- a/Resources/Private/Partials/Bootstrap/Editor.html
+++ b/Resources/Private/Partials/Bootstrap/Editor.html
@@ -1,0 +1,1 @@
+<mmf:form.bbCodeEditor property="text" id="typo3forum_editor_disabled" rows="20" cols="40" class="tx-typo3forum-editor span8" />

--- a/Resources/Private/Partials/Bootstrap/Post/Form.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Form.html
@@ -35,7 +35,7 @@ function validate() {
 			<span class="input-xlarge uneditable-input span8">{topic.subject}</span>
 		</b:form.row>
 		<b:form.row llLabel="Post_New_Text" error="post.text" errorLLPrefix="Post_New_Error_Text">
-			<mmf:form.bbCodeEditor property="text" id="typo3forum_editor" rows="20" cols="40" class="tx-typo3forum-editor span8"/>
+			<f:render partial="Editor" arguments="{_all}" />
 		</b:form.row>
 		<b:form.row llLabel="Post_New_Attachments">
 			<f:if condition="{post.attachments}">

--- a/Resources/Private/Partials/Bootstrap/Post/Single.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Single.html
@@ -14,7 +14,7 @@
 	</f:if>
 	<div class="tx-typo3forum-topic-show-post-text">
 
-        <f:format.html><mmf:format.textParser post="{post}"/></f:format.html>
+        <f:render partial="TextParserOutput" arguments="{_all}" />
 
 		<f:if condition="{post.attachments}">
 			<div class="tx-typo3forum-topic-show-post-attachments">

--- a/Resources/Private/Partials/Bootstrap/TextParserOutput.html
+++ b/Resources/Private/Partials/Bootstrap/TextParserOutput.html
@@ -1,0 +1,1 @@
+<f:format.html><mmf:format.textParser post="{post}"/></f:format.html>

--- a/Resources/Private/Templates/Bootstrap/Moderation/NewReportComment.html
+++ b/Resources/Private/Templates/Bootstrap/Moderation/NewReportComment.html
@@ -12,7 +12,7 @@
 				<f:translate key="Report_NewComment" />
 			</legend>
 			<b:form.row llLabel="Report_NewComment_Text" error="comment.text" errorLLPrefix="Report_NewComment_Error_Text">
-				<m:form.bbCodeEditor class="tx-typo3forum-editor" property="text" id="typo3forum_editor" rows="5" cols="10" />
+				<f:render partial="Editor" arguments="{_all}" />
 			</b:form.row>
 			<div class="form-actions">
 				<f:form.hidden name="report" value="{report}" />

--- a/Resources/Private/Templates/Bootstrap/Report/NewPostReport.html
+++ b/Resources/Private/Templates/Bootstrap/Report/NewPostReport.html
@@ -27,7 +27,7 @@
 				</div>
 			</b:form.row>
 			<b:form.row llLabel="Report_New_Reason" error="firstComment.text" errorLLPrefix="Report_New_Error_Reason">
-				<mmf:form.bbCodeEditor class="tx-typo3forum-editor" property="text" id="typo3forum_editor" rows="5" cols="80" class="span8" />
+				<f:render partial="Editor" arguments="{_all}" />
 			</b:form.row>
 			<div class="form-actions">
 				<f:form.hidden name="post" value="{post}" />

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -34,7 +34,7 @@
 				<f:form.textfield name="subject" value="{subject}" class="span8"/>
 			</b:form.row>
 			<b:form.row llLabel="Topic_New_Text" error="post.text" errorLLPrefix="Topic_New_Error_Post_Text">
-				<mmf:form.bbCodeEditor property="text" id="typo3forum_editor" rows="20" cols="40" class="span8"/>
+				<f:render partial="Editor" arguments="{_all}" />
 			</b:form.row>
 			<b:form.row llLabel="Topic_New_Attachments">
 				<f:if condition="{post.attachments}">

--- a/Resources/Private/Templates/Bootstrap/User/ListMessages.html
+++ b/Resources/Private/Templates/Bootstrap/User/ListMessages.html
@@ -107,8 +107,8 @@
 						<a name="post-create"></a>
 						<f:form controller="User" action="createMessage" class="form-horizontal">
 							<b:form.row error="post" errorLLPrefix="Post_New_Error_Text">
-								<mmf:form.bbCodeEditor class="tx-typo3forum-editor" name="text" property="text" id="typo3forum_editor" rows="20"
-													   class="input-block-level"/>
+							   <!-- class="input-block-level" -->
+								<f:render partial="Editor" arguments="{_all}" />
 							</b:form.row>
 							<f:form.hidden name="recipient" value="{partner.username}"/>
 							<div class="row-fluid">

--- a/Resources/Private/Templates/Bootstrap/User/NewMessage.html
+++ b/Resources/Private/Templates/Bootstrap/User/NewMessage.html
@@ -18,7 +18,8 @@
 				</b:form.row>
 
 				<b:form.row error="text" errorLLPrefix="User_New_Message_Post_Text">
-					<mmf:form.bbCodeEditor name="text" property="text" id="typo3forum_editor" rows="20" cols="40" class="input-block-level"/>
+					<!-- class="input-block-level" -->
+					<f:render partial="Editor" arguments="{_all}" />
 				</b:form.row>
 			</fieldset>
 		</div>


### PR DESCRIPTION
By separating the input text area of forum posts (create and edit) from Fluid templates, it becomes relatively easy to implement any editor and text output handler, e.g. as a separate extension.

It should be noted, that the changes in this commit don't impact the current functionality or visual appearance of the forum at all. The main purpose of this update is to *enable* integrators and developers to build their own solution.

With this change, it is for example possible, to use the [CKEditor](https://ckeditor.com) (in its basic, standard, advanced setup or even a customized configuration). The separate extension only needs to include the CKEditor library in the frontend (incl. its plugins and skins as required) and to provide its own partials `Editor.html` and `TextParserOutput.html`.

Developers can implement further functions as ViewHelpers for example.